### PR TITLE
Update homepage in gemspec

### DIFF
--- a/mailbin.gemspec
+++ b/mailbin.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.version     = Mailbin::VERSION
   spec.authors     = [ "Chris Oliver" ]
   spec.email       = [ "excid3@gmail.com" ]
-  spec.homepage    = "https://github.com"
+  spec.homepage    = "https://github.com/excid3/mailbin"
   spec.summary     = "Mailbin collects emails from Rails ActionMailer in development for testing."
   spec.description = "Mailbin collects emails from Rails ActionMailer in development for testing."
   spec.license     = "MIT"


### PR DESCRIPTION
Noticed that the links from Rubygems were pointing for homepage to`https://github.com` and for the star button to `https://github.com/undefined/undefined`, I guess this should correct it.

![CleanShot 2024-08-06 at 22 27 55](https://github.com/user-attachments/assets/45d77b81-7156-424c-a942-7e95aace6993)
