### PR TITLE
Allow users to override Mailbin storage location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Add `Mailbin.storage_location` config for customizing location where emails are stored
+
 ### 0.1.1
 
 * Use a separate Importmap from the Rails application

--- a/lib/mailbin.rb
+++ b/lib/mailbin.rb
@@ -6,6 +6,7 @@ module Mailbin
   autoload :InlinePreviewInterceptor, "mailbin/inline_preview_interceptor"
 
   mattr_accessor :importmap, default: Importmap::Map.new
+  mattr_accessor :storage_location
 
   class << self
     def all

--- a/lib/mailbin/engine.rb
+++ b/lib/mailbin/engine.rb
@@ -6,11 +6,13 @@ module Mailbin
     isolate_namespace Mailbin
 
     initializer "mailbin.add_delivery_method" do
+      Mailbin.storage_location ||= Rails.root.join("tmp", "mailbin")
+
       ActiveSupport.on_load :action_mailer do
         ActionMailer::Base.add_delivery_method(
           :mailbin,
           Mailbin::DeliveryMethod,
-          location: Rails.root.join("tmp", "mailbin")
+          location: Mailbin.storage_location
         )
       end
     end


### PR DESCRIPTION
This allows users to override the Mailbin storage location with their own initializer.

```ruby
# config/initializers/mailbin.rb
Mailbin.storage_location = ENV["MAILBIN_STORAGE_LOCATION"] || Rails.root.join("mail-storage")
```

Closes #65