### PR TITLE
Use comma-separated `rgb()` in `application.css` for sass-rails / SassC compatibility

### DIFF
--- a/app/assets/stylesheets/mailbin/application.css
+++ b/app/assets/stylesheets/mailbin/application.css
@@ -90,10 +90,10 @@ nav {
   padding-right: 0.35rem;
   padding-top: 0.125rem;
   background-color: white;
-  color: rgb(31 41 55);
-  border-color: rgb(156 163 175);
+  color: rgb(31, 41, 55);
+  border-color: rgb(156, 163, 175);
 
   &:hover {
-    background-color: rgb(243 244 246);
+    background-color: rgb(243, 244, 246);
   }
 }


### PR DESCRIPTION
## Summary

Replace **space-separated** `rgb()` values with **comma-separated** `rgb()` so host apps using **`sass-rails`** (Sprockets + **SassC** CSS compression) can run `rake assets:precompile` without errors. Colors are unchanged.

## How we reproduced it

This showed up in a **Rails 7.1** app using:

- **`sass-rails` ~> 6** (Sprockets runs the **SassC**-based CSS compressor during precompile)
- **`mailbin` ~> 1.1** from RubyGems, with the engine mounted

**`bundle exec rake assets:precompile`** failed until this CSS change.

## Problem

In Rails apps that compress CSS through LibSass (**SassC**), `assets:precompile` can fail with:

```text
SassC::SyntaxError: Error: Function rgb is missing argument $green.
        on line 93 of stdin
>>   color: rgb(31 41 55);
```

SassC parses `rgb()` as the legacy Sass `rgb()` function and does not accept **CSS Color Module 4** space-separated channel syntax, even though that syntax is valid in modern browsers.

## Root cause

In `app/assets/stylesheets/mailbin/application.css`, the `.btn` styles used:

- `color: rgb(31 41 55);`
- `border-color: rgb(156 163 175);`
- `background-color: rgb(243 244 246);` (hover)

Those lines were added in [`7a2de99`](https://github.com/excid3/mailbin/commit/7a2de99f845e2162d164d969146ed9f7bc0d6f81) (“Separate importmap and add some styling.”).

## Fix

Use comma-separated `rgb()` (same computed colors):

| Property (context)   | Before                     | After                          |
| -------------------- | -------------------------- | ------------------------------ |
| `.btn` color         | `rgb(31 41 55)`            | `rgb(31, 41, 55)`              |
| `.btn` border-color  | `rgb(156 163 175)`         | `rgb(156, 163, 175)`           |
| `.btn:hover` bg      | `rgb(243 244 246)`         | `rgb(243, 244, 246)`           |

No visual change intended.
