### PR TITLE
Allow EML files to be directly downloadable

### DIFF
--- a/app/controllers/mailbin/messages_controller.rb
+++ b/app/controllers/mailbin/messages_controller.rb
@@ -2,7 +2,7 @@ module Mailbin
   class MessagesController < ApplicationController
     around_action :set_locale, only: [ :show ]
 
-    helper_method :attachment_url, :part_query, :locale_query
+    helper_method :attachment_url, :eml_url, :part_query, :locale_query
 
     content_security_policy(false)
 
@@ -68,6 +68,10 @@ module Mailbin
 
     def attachment_url(attachment)
       "data:application/octet-stream;charset=utf-8;base64,#{Base64.encode64(attachment.body.to_s)}"
+    end
+
+    def eml_url(email)
+      "data:message/rfc822;charset=utf-8;base64,#{Base64.encode64(email.to_s)}"
     end
 
     def part_query(mime_type)

--- a/app/views/mailbin/messages/show.html.erb
+++ b/app/views/mailbin/messages/show.html.erb
@@ -100,7 +100,7 @@
     <% end %>
 
     <dt>EML File:</dt>
-    <dd><%= Mailbin.location_for(params[:id]) %></dd>
+    <dd><%= link_to Mailbin.location_for(params[:id]), eml_url(@email), download: File.basename(Mailbin.location_for(params[:id])) %></dd>
   </dl>
 </header>
 


### PR DESCRIPTION
This is 100% a convenience thing because I'm too lazy to highlight the path in the UI and copy/paste into `cp` in a terminal or dig around in the tmp directory looking for the specific file.

Changes:

- Added an `eml_url` helper that encodes the raw message as a message/rfc822 data URL.
- Changed the eml path in the show view to also be a link to download a file.